### PR TITLE
Adjust links to WebCodecs

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,9 +239,10 @@
 
             <dt id="web-codecs" class="spec">WebCodecs</dt>
             <dd>
-              <p>This new specification defines interfaces for encoding and decoding audio and video.</p>
-              <p class="draft-status"><b>Draft state</b>: <span class="todo"><a href="https://www.w3.org/TR/">Working Draft</a></span></p>
-            </dd>
+              <p>This specification defines interfaces for encoding and decoding audio and video.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webcodecs/">Working Draft</a></p>
+              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webcodecs-20210408/">WebCodecs</a>,
+              associated <a href="https://www.w3.org/mid/cfe-7971-897e1d3aef58cd7a9e8b92552516fd19c1692a51@w3.org">Call for Exclusion</a> on 08-Apr-2021 will end on 05-Sep-2021. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>
           </dl>
         </section>
 
@@ -273,6 +274,13 @@
             <li><a href="https://www.w3.org/TR/eme-stream-mp4/">ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format</a></li>
             <li><a href="https://www.w3.org/TR/eme-stream-webm/">WebM Stream Format</a></li>
           </ul>
+
+          <p>To enhance interoperability among implementations and users of WebCodecs, the Media Working Group will also maintain a non-normative registry for the specification, and develop non-normative codec-specific registrations. This includes the following Working Drafts, intended to become Notes:</p>
+          <ul>
+            <li><a href="https://www.w3.org/TR/webcodecs-codec-registry/">WebCodecs Codec Registry</a></li>
+            <li><a href="https://www.w3.org/TR/webcodecs-avc-codec-registration/">AVC (H.264) WebCodecs Registration</a></li>
+          </ul>
+
           <p>Other non-normative documents may be created such as:</p>
           <ul>
             <li>Use case and requirement documents;</li>
@@ -339,7 +347,7 @@
               </tr>
               <tr>
                 <th>WebCodecs</th>
-                <td>Q1 2021</td>
+                <td>Q2 2021</td>
                 <td>Q2 2022</td>
                 <td>Q1 2023</td>
                 <td>Q2 2023</td>


### PR DESCRIPTION
The specification was published as First Public Working Draft last week, along with a non-normative registry and a non-normative registration for AVC (H.264), explicitly mentioned in the "Other deliverables" section.

The update also adjusts the timeline for WebCodecs accordingly.

Fixes #17.