### PR TITLE
Update description of WebCodecs spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
 
             <dt id="web-codecs" class="spec">WebCodecs</dt>
             <dd>
-              <p>This specification defines interfaces for encoding and decoding audio and video.</p>
+              <p>This specification defines interfaces for encoding and decoding of audio, video, and images.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webcodecs/">Working Draft</a></p>
               <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webcodecs-20210408/">WebCodecs</a>,
               associated <a href="https://www.w3.org/mid/cfe-7971-897e1d3aef58cd7a9e8b92552516fd19c1692a51@w3.org">Call for Exclusion</a> on 08-Apr-2021 will end on 05-Sep-2021. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>


### PR DESCRIPTION
Reflects the fact that the API can also be used for encoding and decoding of images.

Closes #26.