### PR TITLE
Incorporate latest changes made to charter template

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,11 +97,19 @@
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/media-wg/">Media Working Group</a> is to develop and improve client-side media processing and playback features on the Web.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/115198/join">Join the Media Working Group</a>.</p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/media/join">Join the Media Working Group</a>.</p>
       </div>
 
-      <section id="details">
+      <div id="details">
         <table class="summary-table">
+          <tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              <i class="todo">See the <a href="https://www.w3.org/groups/wg/media/charters">group status page</A> and <a href="#history">detailed change history</a>.</i>
+            </td>
+          </tr>
           <tr id="Duration">
             <th>
               Start date
@@ -153,7 +161,7 @@
             </td>
           </tr>
         </table>
-      </section>
+      </div>
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
@@ -364,18 +372,18 @@
 
       <section id="success-criteria">
         <h2>Success Criteria</h2>
-        <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of each of feature defined in the specification.</p>
-        <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users, including analysis of <a href="https://www.w3.org/TR/fingerprinting-guidance/">fingerprinting surface introduced</a> and suggested mitigation strategies, as applicable. For features that allow detection and/or negotiation of capabilities, the group will document architectural alternatives, particularly ones that minimize fingerprinting surface, and seek horizontal review as it makes its choice(s) among the alternatives. Where features are imported by reference to other specifications, analysis and mitigation of their privacy and security issues will be included in the referencing specification.</p>
+        <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable implementations</a> of every feature defined in the specification, where interoperability can be verified by passing open test suites, and two or more implementations interoperating with each other. In order to advance to Proposed Recommendation, each normative specification must have an open test suite of every feature defined in the specification.</p>
         <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+        <p>To promote interoperability, all changes made to specifications in Candidate Recommendation or to features that have deployed implementations should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>. Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
+        <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users, including analysis of <a href="https://www.w3.org/TR/fingerprinting-guidance/">fingerprinting surface introduced</a> and suggested mitigation strategies, as applicable. For features that allow detection and/or negotiation of capabilities, the group will document architectural alternatives, particularly ones that minimize fingerprinting surface, and seek horizontal review as it makes its choice(s) among the alternatives. Where features are imported by reference to other specifications, analysis and mitigation of their privacy and security issues will be included in the referencing specification.</p>
         <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations. The latest versions of the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a> and <a href="https://w3c.github.io/apa/fast/">Framework for Accessible Specification of Technologies (FAST)</a> documents notably provide media related advice to ensure that specifications developed by the Working Group meet the needs of users with disabilities.</p>
-        <p>To promote interoperability, all changes made to specifications should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.</p>
       </section>
 
       <section id="coordination">
         <h2>Coordination</h2>
         <p>For all specifications, this Working Group will seek
           <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a>
-          for accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          for accessibility, internationalization, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
           <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
@@ -477,7 +485,7 @@
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
            However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>
@@ -492,7 +500,7 @@
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
         </p>
         <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 3.4, Votes)</a> and includes no voting procedures beyond what the Process Document requires.
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
         </p>
       </section>
 
@@ -503,7 +511,7 @@
         <p>
           This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/media/ipr">W3C Patent Policy Implementation</a>.
         </p>
       </section>
 
@@ -517,14 +525,14 @@
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">
           <h3>
             Charter History
           </h3>
-          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
           <table class="history">
             <tbody>
@@ -618,16 +626,11 @@
       </address>
 
       <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2021
-        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
-        (
-        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="https://www.keio.ac.jp/">Keio</a>,
-        <a href="https://ev.buaa.edu.cn/">Beihang</a>
-        ), All Rights Reserved.
-
-        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+        Copyright © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+        <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+        <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
       </p>
     </footer>
   </body>


### PR DESCRIPTION
This update synchronizes the "boilerplate" content of the charter with that of the template: https://w3c.github.io/charter-drafts/charter-template.html

This does not introduce changes to the scope, list of deliverables as well as to commitments that participation in the Media Working Group require.