### PR TITLE
Refresh the list of deliverables

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
       <h1 id="title"><i class="todo">[PROPOSED]</i> Media Working Group Charter</h1>
 
       <div class="info">
-        <p>This document is a draft charter that gets proposed for discussion and review by the W3C Advisory Committee when the group needs to recharter. It is not under active discussion for the time being. Please see the <a href="https://www.w3.org/2021/07/media-wg-charter.html">approved charter</a>.</p>
+        <p>This document is a draft charter proposed for discussion and review by the W3C Advisory Committee. It is available on <a href="https://github.com/w3c/charter-media-wg/">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/charter-media-wg/issues">issues</a>.</p>
       </div>
 
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/media-wg/">Media Working Group</a> is to develop and improve client-side media processing and playback features on the Web.</p>
@@ -115,7 +115,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">TBD</i>
+              <i class="todo">When approved</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -123,7 +123,7 @@
               End date
             </th>
             <td>
-              <i class="todo">31 May 2023</i>
+              <span class="todo">Start date + 2 years</span>
             </td>
           </tr>
 
@@ -190,7 +190,8 @@
 
       <section id="deliverables">
         <h2>Deliverables</h2>
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/media/publications">group publication status page</a>.</p>
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state. <i><a href="https://www.w3.org/2021/Process-20211102/#adopted-draft">Adopted Draft</a></i>, <i><a href="https://www.w3.org/2021/Process-20211102/#exclusion-draft">Exclusion Draft</a></i> and <i><a href="https://www.w3.org/2021/Process-20211102/#exclusion-draft-charter">Exclusion Draft Charter</a></i> are defined in the W3C Process Document (section 4.2, Content of a Charter).</p>
 
         <section id="normative">
           <h3>Normative Specifications</h3>
@@ -199,25 +200,31 @@
             <dt id="media-capabilities" class="spec">Media Capabilities</dt>
             <dd>
               <p>This specification provides APIs to allow websites to make an optimal decision when picking media content for the user. The APIs expose information about the decoding and encoding capabilities for a given format but also output capabilities to find the best match based on the device’s display.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-capabilities/">Working Draft</a></p>
-              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2020/WD-media-capabilities-20200130/">Media Capabilities</a>,
-              associated <a href="https://www.w3.org/mid/cfe-7317-59a925fa443874f021cb50f508f609d17f46a71f@w3.org">Call for Exclusion</a> on 30-Jan-2020 ended on 28-Jun-2020. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-capabilities/">Working Draft</a>.</p>
+              <p><b>Adopted Draft:</b> Media Capabilities, <a href="https://www.w3.org/TR/2022/WD-media-capabilities-20221117/">https://www.w3.org/TR/2022/WD-media-capabilities-20221117/</a>, 17 November 2022</a>.</p>
+              <p><b>Exclusion Draft:</b> Media Capabilities, <a href="https://www.w3.org/TR/2020/WD-media-capabilities-20200130/">https://www.w3.org/TR/2020/WD-media-capabilities-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7317-59a925fa443874f021cb50f508f609d17f46a71f@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2019/05/media-wg-charter.html">https://www.w3.org/2019/05/media-wg-charter.html</a>.</p>
             </dd>
 
             <dt id="picture-in-picture" class="spec">Picture-in-Picture</dt>
             <dd>
               <p>This specification defines APIs to allow websites to create a floating video window always on top of other windows so that users may continue consuming media while they interact with other content sites or applications on their device.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/picture-in-picture/">Working Draft</a></p>
-              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2020/WD-picture-in-picture-20200130/">Picture-in-Picture</a>,
-              associated <a href="https://www.w3.org/mid/cfe-7318-181f066213608055a0623551e545ab15fe1d9656@w3.org">Call for Exclusion</a> on 30-Jan-2020 ended on 28-Jun-2020. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/picture-in-picture/">Working Draft</a>.</p>
+              <p><b>Adopted Draft:</b> Picture-in-Picture, <a href="https://www.w3.org/TR/2022/WD-picture-in-picture-20221219/">https://www.w3.org/TR/2022/WD-picture-in-picture-20221219/</a>, 19 December 2022</a>.</p>
+              <p><b>Exclusion Draft:</b> Picture-in-Picture, <a href="https://www.w3.org/TR/2020/WD-picture-in-picture-20200130/">https://www.w3.org/TR/2020/WD-picture-in-picture-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7318-181f066213608055a0623551e545ab15fe1d9656@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2019/05/media-wg-charter.html">https://www.w3.org/2019/05/media-wg-charter.html</a>.</p>
             </dd>
 
             <dt id="mediasession" class="spec">Media Session</dt>
             <dd>
               <p>This specification enables web developers to show customized media metadata on platform UI, customize available platform media controls, and access platform media keys such as hardware keys found on keyboards, headsets, remote controls, and software keys found in notification areas and on lock screens of mobile devices.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/mediasession/">Working Draft</a></p>
-              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2020/WD-mediasession-20200130/">Media Session Standard</a>,
-              associated <a href="https://www.w3.org/mid/cfe-7319-389a01befd6ccf9971e1bb549656e9543dee3ade@w3.org">Call for Exclusion</a> on 30-Jan-2020 ended on 28-Jun-2020. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/mediasession/">Working Draft</a>.</p>
+              <p><b>Adopted Draft:</b> Media Session Standard, <a href="https://www.w3.org/TR/2022/WD-mediasession-20220920/">https://www.w3.org/TR/2022/WD-mediasession-20220920/</a>, 20 September 2022</a>.</p>
+              <p><b>Exclusion Draft:</b> Media Session Standard, <a href="https://www.w3.org/TR/2020/WD-mediasession-20200130/">https://www.w3.org/TR/2020/WD-mediasession-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7319-389a01befd6ccf9971e1bb549656e9543dee3ade@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2019/05/media-wg-charter.html">https://www.w3.org/2019/05/media-wg-charter.html</a>.</p>
             </dd>
 
             <dt id="media-playback-quality" class="spec">Media Playback Quality</dt>
@@ -230,13 +237,21 @@
             <dt id="autoplay" class="spec">Autoplay Policy Detection</dt>
             <dd>
               <p>This new specification provides APIs to allow websites to determine the document-level autoplay policy and whether autoplay will succeed for a given media element in a page.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://github.com/w3c/autoplay/">Editor's Draft</a></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/autoplay-detection/">Working Draft</a>.</p>
+              <p><b>Adopted Draft:</b> Autoplay Policy Detection, <a href="https://www.w3.org/TR/2023/WD-autoplay-detection-20230127/">https://www.w3.org/TR/2023/WD-autoplay-detection-20230127/</a>, 27 January 2023</a>.</p>
+              <p><b>Exclusion Draft:</b> Autoplay Policy Detection, <a href="https://www.w3.org/TR/2022/WD-autoplay-detection-20220315/">https://www.w3.org/TR/2022/WD-autoplay-detection-20220315/</a>, 15 March 2022. <a href="https://www.w3.org/mid/cfe-9402-1e89a77f007eda6d5303ab8e8a9ea2f14210e495@w3.org">Exclusion period</a> began on 15 March 2022; ended on 12 December 2022.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2021/07/media-wg-charter.html">https://www.w3.org/2021/07/media-wg-charter.html</a>.</p>
             </dd>
 
             <dt id="media-source" class="spec">Media Source Extensions</dt>
             <dd>
               <p>This specification extends the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface defined in <a href="https://html.spec.whatwg.org/">HTML</a> to allow JavaScript to generate media streams for playback. The scope of this revision is the same as that of the <a href='https://www.w3.org/TR/media-source/'>W3C Recommendation published in November 2016</a>, limited to the generation and control of media streams. This revision updates the W3C Recommendation to address maintenance issues against the specification and add the <a href="https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md">codec switching</a> feature incubated in the Web Platform Incubator Community Group since then. Additional features that are strictly in the scope of this specification may be considered.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/media-source/">Editor's Draft</a></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-soure-2/">Working Draft</a>.</p>
+              <p><b>Adopted Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2022/WD-media-source-2-20220921/">https://www.w3.org/TR/2022/WD-media-source-2-20220921/</a>, 21 September 2022</a>.</p>
+              <p><b>Exclusion Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2021/WD-media-source-2-20210930/">https://www.w3.org/TR/2021/WD-media-source-2-20210930/</a>, 30 September 2021. <a href="https://www.w3.org/mid/cfe-8675-39f9f88b37a13eb18f261d2f0d163f4be7710cf5@w3.org">Exclusion period</a> began on 30 September 2021; ended on 27 February 2022.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2021/07/media-wg-charter.html">https://www.w3.org/2021/07/media-wg-charter.html</a>.</p>
             </dd>
 
             <dt id="encrypted-media" class="spec">Encrypted Media Extensions</dt>
@@ -248,9 +263,18 @@
             <dt id="web-codecs" class="spec">WebCodecs</dt>
             <dd>
               <p>This specification defines interfaces for encoding and decoding of audio, video, and images.</p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webcodecs/">Working Draft</a></p>
-              <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webcodecs-20210408/">WebCodecs</a>,
-              associated <a href="https://www.w3.org/mid/cfe-7971-897e1d3aef58cd7a9e8b92552516fd19c1692a51@w3.org">Call for Exclusion</a> on 08-Apr-2021 will end on 05-Sep-2021. Produced under the <a href="https://www.w3.org/2019/05/media-wg-charter.html">previous Working Group Charter</a></p>
+              <p><b>Adopted Draft:</b> WebCodecs, <a href="https://www.w3.org/TR/2023/WD-webcodecs-20230130/">https://www.w3.org/TR/2023/WD-webcodecs-20230130/</a>, 30 January 2023</a>.</p>
+              <p><b>Exclusion Draft:</b> WebCodecs, <a href="https://www.w3.org/TR/2021/WD-webcodecs-20210408/">https://www.w3.org/TR/2021/WD-webcodecs-20210408/</a>, 08 April 2021. <a href="https://www.w3.org/mid/cfe-7971-897e1d3aef58cd7a9e8b92552516fd19c1692a51@w3.org">Exclusion period</a> began on 08 April 2021; ended on 05 September 2021.</p>
+              <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2019/05/media-wg-charter.html">https://www.w3.org/2019/05/media-wg-charter.html</a>.</p>
+            </dd>
+
+            <dt id="audio-focus" class="spec">Audio Focus</dt>
+            <dd>
+              <p>This specification allows web applications to manage their audio focus, to improve the audio-mixing of websites with native apps so they can play on top of each other or play exclusively.</p>
+              <p class="draft-status"><b>Draft state:</b> <span class="todo">Editor's Draft</span></p>
+            </dd>
           </dl>
         </section>
 
@@ -258,115 +282,75 @@
           <h3>Potential Normative Specifications</h3>
           <p>The following features have been identified as potential normative specifications and may be adopted as normative specifications by the Working Group if there is consensus in the group that they are ready to move to the Recommendation track:</p>
           <dl>
-            <dt><a href="https://github.com/WICG/audio-focus/blob/master/explainer.md">Audio Focus API</a></dt>
-            <dd>An API to allow web applications to manage their audio focus, to improve the audio-mixing of websites with native apps so they can play on top of each other or play exclusively.</dd>
             <dt><a href="https://github.com/WICG/datacue/blob/master/explainer.md">DataCue</a></dt>
             <dd>An API to support metadata event tracks, carried either in-band or out-of-band and synchronized to audio or video media, which are used to support use cases such as ad insertion or presentation of supplemental content alongside the audio or video. This includes the possible adoption of the <a href="https://dev.w3.org/html5/html-sourcing-inband-tracks/">Sourcing In-band Media Resource Tracks from Media Containers into HTML</a> document to specify the handling of in-band events.</dd>
-            <dt>Stream format specifications and accompanying registries</dt>
-            <dd>Notes described in <a href="#other-deliverables">Other Deliverables</a> define optional features for Media Source Extensions and Encrypted Media Extensions. The Working Group may move them to the Recommendation track.</dd>
+            <dt>Registration specifications</dt>
+            <dd>Notes described in <a href="#registries">Registries</a> define optional features for WebCodecs, Media Source Extensions, Encrypted Media Extensions. The Working Group may move them to the Recommendation track.</dd>
           </dl>
 
           <p>The Working Group will not adopt these features until they have matured through the <a href="https://wicg.io/">Web Platform Incubator Community Group</a> or another similar incubation phase. If additional normative specifications need to be added to the Charter before the Charter expires, the Working Group will recharter with changes.</p>
         </section>
 
-        <section id="other-deliverables">
-          <h3>Other Deliverables</h3>
-          <p>The Media Working Group will maintain non-normative stream format specifications for Media Source Extensions and Encrypted Media Extensions, develop new stream format specifications, and update corresponding registries. It will maintain the following Notes in particular:</p>
+        <section id="registries">
+          <h3>Registries</h3>
+
+          <p>To enhance interoperability among implementations and users the Media Working Group develops and maintains registries for WebCodecs, Media Source Extensions, and Encrypted Media Extensions:</p>
+
           <ul>
-            <li><a href="https://www.w3.org/TR/mse-byte-stream-format-registry/">Media Source Extensions Byte Stream Format Registry</a></li>
-            <li><a href="https://www.w3.org/TR/eme-stream-registry/">Encrypted Media Extensions Stream Format Registry</a></li>
-            <li><a href="https://www.w3.org/TR/mse-byte-stream-format-isobmff/">ISO BMFF Byte Stream Format</a></li>
-            <li><a href="https://www.w3.org/TR/mse-byte-stream-format-mp2t/">MPEG-2 Transport Streams Byte Stream Format</a></li>
-            <li><a href="https://www.w3.org/TR/mse-byte-stream-format-mpeg-audio/">MPEG Audio Byte Stream Format</a></li>
-            <li><a href="https://www.w3.org/TR/mse-byte-stream-format-webm/">WebM Byte Stream Format</a></li>
-            <li><a href="https://www.w3.org/TR/eme-stream-mp4/">ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format</a></li>
-            <li><a href="https://www.w3.org/TR/eme-stream-webm/">WebM Stream Format</a></li>
+            <li>The <a href="https://www.w3.org/TR/webcodecs-codec-registry/">WebCodecs Codec Registry</a> provides the means to identify and avoid collisions among codec strings used in WebCodecs and provides a mechanism to define codec-specific members of WebCodecs codec configuration dictionaries.</li>
+            <li>The <a href="https://w3c.github.io/webcodecs/video_frame_metadata_registry.html">WebCodecs VideoFrame Metadata Registry</a> enumerates the metadata fields that can be attached to VideoFrame objects via the VideoFrameMetadata dictionary.</li>
+            <li>The <a href="https://www.w3.org/TR/mse-byte-stream-format-registry/">Media Source Extensions Byte Stream Format Registry</a> defines the byte stream formats for use with the Media Source Extensions specification.</li>
+            <li>The <a href="https://www.w3.org/TR/eme-stream-registry/">Encrypted Media Extensions Stream Format Registry</a> defines the stream formats for use with the Encrypted Media Extensions specification.</li>
           </ul>
 
-          <p>To enhance interoperability among implementations and users of WebCodecs, the Media Working Group will also maintain a non-normative registry for the specification, and develop non-normative codec-specific registrations. This includes the following Working Drafts, intended to become Notes:</p>
-          <ul>
-            <li><a href="https://www.w3.org/TR/webcodecs-codec-registry/">WebCodecs Codec Registry</a></li>
-            <li><a href="https://www.w3.org/TR/webcodecs-avc-codec-registration/">AVC (H.264) WebCodecs Registration</a></li>
-          </ul>
+          <p>The Media Working Group may re-publish registries published as Notes on the Registry track.</p>
 
-          <p>Other non-normative documents may be created such as:</p>
+          <p>The Media Working Group also develops and maintains non-normative codec-specific or format-specific registrations for each of these registries, published on the Note track. These include:</p>
+
           <ul>
-            <li>Use case and requirement documents;</li>
-            <li>Test suite and implementation report for the specifications;</li>
-            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+            <li>For the WebCodecs Codec Registry:
+              <ul>
+                <li><a href="https://www.w3.org/TR/webcodecs-alaw-codec-registration/">A-law PCM WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-aac-codec-registration/">AAC WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-av1-codec-registration/">AV1 WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-avc-codec-registration/">AVC (H.264) WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-flac-codec-registration/">FLAC WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-hevc-codec-registration/">HEVC (H.265) WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-pcm-codec-registration/">Linear PCM WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-mp3-codec-registration/">MP3 WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-opus-codec-registration/">Opus WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-ulaw-codec-registration/">u-law PCM WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-vorbis-codec-registration/">Vorbis WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-vp8-codec-registration/">VP8 WebCodecs Registration</a></li>
+                <li><a href="https://www.w3.org/TR/webcodecs-vp9-codec-registration/">VP9 WebCodecs Registration</a></li>
+              </ul>
+            </li>
+            <li>For the Media Source Extensions Byte Stream Format Registry:
+              <ul>
+                <li><a href="https://www.w3.org/TR/mse-byte-stream-format-isobmff/">ISO BMFF Byte Stream Format</a></li>
+                <li><a href="https://www.w3.org/TR/mse-byte-stream-format-mp2t/">MPEG-2 Transport Streams Byte Stream Format</a></li>
+                <li><a href="https://www.w3.org/TR/mse-byte-stream-format-mpeg-audio/">MPEG Audio Byte Stream Format</a></li>
+                <li><a href="https://www.w3.org/TR/mse-byte-stream-format-webm/">WebM Byte Stream Format</a></li>
+              </ul>
+            </li>
+            <li>For the Encrypted Media Extensions Stream Format Registry:
+              <ul>
+                <li><a href="https://www.w3.org/TR/eme-stream-mp4/">ISO Common Encryption ('cenc') Protection Scheme for ISO Base Media File Format Stream Format</a></li>
+                <li><a href="https://www.w3.org/TR/eme-stream-webm/">WebM Stream Format</a></li>
+              </ul>
+            </li>
           </ul>
         </section>
 
-        <section id="timeline">
-          <h3>Timeline</h3>
-          <table class="roadmap">
-            <caption>Milestones</caption>
-            <thead>
-              <tr>
-                <th>Specification</th>
-                <th><abbr title="First Working Draft">FPWD</abbr></th>
-                <th><abbr title="Candidate Recommendation">CR</abbr></th>
-                <th><abbr title="Proposed Recommendation">PR</abbr></th>
-                <th><abbr title="Recommendation">Rec</abbr></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th>Media Capabilities</th>
-                <td>Q1 2020</td>
-                <td>Q3 2021</td>
-                <td>Q2 2022</td>
-                <td>Q2 2022</td>
-              </tr>
-              <tr>
-                <th>Picture-in-Picture</th>
-                <td>Q1 2020</td>
-                <td>Q3 2021</td>
-                <td>Q2 2022</td>
-                <td>Q2 2022</td>
-              </tr>
-              <tr>
-                <th>Media Session</th>
-                <td>Q1 2020</td>
-                <td>Q3 2021</td>
-                <td>Q2 2022</td>
-                <td>Q2 2022</td>
-              </tr>
-              <tr>
-                <th>Autoplay Policy Detection</th>
-                <td>Q4 2021</td>
-                <td>Q2 2022</td>
-                <td>Q1 2023</td>
-                <td>Q2 2023</td>
-              </tr>
-              <tr>
-                <th>Media Source Extensions</th>
-                <td>Q2 2021</td>
-                <td>Q1 2022</td>
-                <td>Q4 2022</td>
-                <td>Q1 2023</td>
-              </tr>
-              <tr>
-                <th>Encrypted Media Extensions</th>
-                <td>Q4 2021</td>
-                <td>Q3 2022</td>
-                <td>Q1 2023</td>
-                <td>Q2 2023</td>
-              </tr>
-              <tr>
-                <th>WebCodecs</th>
-                <td>Q2 2021</td>
-                <td>Q2 2022</td>
-                <td>Q1 2023</td>
-                <td>Q2 2023</td>
-              </tr>
-            </tbody>
-          </table>
-          <p><em>
-            Note: The actual production of some of the deliverables may
-              follow a different timeline. Schedule changes will be documented on
-              the <a href="https://www.w3.org/media-wg/">group home page</a>.
-          </em></p>
+        <section id="other-deliverables">
+          <h3>Other Deliverables</h3>
+
+          <p>Other non-normative documents may be created such as:</p>
+          <ul>
+            <li>Use cases and requirements documents;</li>
+            <li>Test suites and implementation reports for the specifications;</li>
+            <li>Code samples, Primers or Best Practices documents to support web developers when designing applications.</li>
+          </ul>
         </section>
       </section>
 
@@ -609,6 +593,25 @@
                     <li>Added WebCodecs to the list of deliverables</li>
                     <li>Dropped Persistent usage record sessions feature from EME description</li>
                     <li>Updated milestones and coordination list</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2021/07/media-wg-charter.html">Rechartered</a>
+                </th>
+                <td>
+                  <span class="todo">When approved</span>
+                </td>
+                <td>
+                  <span class="todo">Start date + 2 years</span>
+                </td>
+                <td>
+                  <ul>
+                    <li>Adjusted boilerplate text to match latest charter template</li>
+                    <li>Added Registries section to highlight registries and registration deliverables</li>
+                    <li>Replaced milestones table with expected completion dates</li>
+                    <li><span class="todo">document changes</span></li>
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
Main changes:
- The Audio Focus API was moved from "potential" to the official list of deliverables for the group
- List of normative deliverables refreshed to meet requirements imposed by the W3C Process Document (notably adopted draft, exclusion draft, exclusion draft charter)
- New "Registries" section added that lists registries and registrations that the group develops.
- A note clarifies that registries currently published on the Note track may get re-published on the Registry track.
- Note that gave the WG some leeway to move non-normative notes to the Rec track adjusted to also encompass WebCodecs registrations.

Expected completion dates still need to be filled out.