### PR TITLE
Add expected completion dates

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
             <dt id="media-capabilities" class="spec">Media Capabilities</dt>
             <dd>
               <p>This specification provides APIs to allow websites to make an optimal decision when picking media content for the user. The APIs expose information about the decoding and encoding capabilities for a given format but also output capabilities to find the best match based on the device’s display.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q4 2023 - Recommendation Q4 2024.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-capabilities/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Media Capabilities, <a href="https://www.w3.org/TR/2022/WD-media-capabilities-20221117/">https://www.w3.org/TR/2022/WD-media-capabilities-20221117/</a>, 17 November 2022</a>.</p>
               <p><b>Exclusion Draft:</b> Media Capabilities, <a href="https://www.w3.org/TR/2020/WD-media-capabilities-20200130/">https://www.w3.org/TR/2020/WD-media-capabilities-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7317-59a925fa443874f021cb50f508f609d17f46a71f@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
@@ -210,7 +210,7 @@
             <dt id="picture-in-picture" class="spec">Picture-in-Picture</dt>
             <dd>
               <p>This specification defines APIs to allow websites to create a floating video window always on top of other windows so that users may continue consuming media while they interact with other content sites or applications on their device.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q4 2023 - Recommendation Q4 2024.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/picture-in-picture/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Picture-in-Picture, <a href="https://www.w3.org/TR/2022/WD-picture-in-picture-20221219/">https://www.w3.org/TR/2022/WD-picture-in-picture-20221219/</a>, 19 December 2022</a>.</p>
               <p><b>Exclusion Draft:</b> Picture-in-Picture, <a href="https://www.w3.org/TR/2020/WD-picture-in-picture-20200130/">https://www.w3.org/TR/2020/WD-picture-in-picture-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7318-181f066213608055a0623551e545ab15fe1d9656@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
@@ -220,7 +220,7 @@
             <dt id="mediasession" class="spec">Media Session</dt>
             <dd>
               <p>This specification enables web developers to show customized media metadata on platform UI, customize available platform media controls, and access platform media keys such as hardware keys found on keyboards, headsets, remote controls, and software keys found in notification areas and on lock screens of mobile devices.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/mediasession/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Media Session Standard, <a href="https://www.w3.org/TR/2022/WD-mediasession-20220920/">https://www.w3.org/TR/2022/WD-mediasession-20220920/</a>, 20 September 2022</a>.</p>
               <p><b>Exclusion Draft:</b> Media Session Standard, <a href="https://www.w3.org/TR/2020/WD-mediasession-20200130/">https://www.w3.org/TR/2020/WD-mediasession-20200130/</a>, 30 January 2020. <a href="https://www.w3.org/mid/cfe-7319-389a01befd6ccf9971e1bb549656e9543dee3ade@w3.org">Exclusion period</a> began on 30 January 2020; ended on 28 June 2020.</p>
@@ -237,7 +237,7 @@
             <dt id="autoplay" class="spec">Autoplay Policy Detection</dt>
             <dd>
               <p>This new specification provides APIs to allow websites to determine the document-level autoplay policy and whether autoplay will succeed for a given media element in a page.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/autoplay-detection/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Autoplay Policy Detection, <a href="https://www.w3.org/TR/2023/WD-autoplay-detection-20230127/">https://www.w3.org/TR/2023/WD-autoplay-detection-20230127/</a>, 27 January 2023</a>.</p>
               <p><b>Exclusion Draft:</b> Autoplay Policy Detection, <a href="https://www.w3.org/TR/2022/WD-autoplay-detection-20220315/">https://www.w3.org/TR/2022/WD-autoplay-detection-20220315/</a>, 15 March 2022. <a href="https://www.w3.org/mid/cfe-9402-1e89a77f007eda6d5303ab8e8a9ea2f14210e495@w3.org">Exclusion period</a> began on 15 March 2022; ended on 12 December 2022.</p>
@@ -247,7 +247,7 @@
             <dt id="media-source" class="spec">Media Source Extensions</dt>
             <dd>
               <p>This specification extends the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface defined in <a href="https://html.spec.whatwg.org/">HTML</a> to allow JavaScript to generate media streams for playback. The scope of this revision is the same as that of the <a href='https://www.w3.org/TR/media-source/'>W3C Recommendation published in November 2016</a>, limited to the generation and control of media streams. This revision updates the W3C Recommendation to address maintenance issues against the specification and add the <a href="https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md">codec switching</a> feature incubated in the Web Platform Incubator Community Group since then. Additional features that are strictly in the scope of this specification may be considered.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q4 2023 - Recommendation Q4 2024.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-soure-2/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2022/WD-media-source-2-20220921/">https://www.w3.org/TR/2022/WD-media-source-2-20220921/</a>, 21 September 2022</a>.</p>
               <p><b>Exclusion Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2021/WD-media-source-2-20210930/">https://www.w3.org/TR/2021/WD-media-source-2-20210930/</a>, 30 September 2021. <a href="https://www.w3.org/mid/cfe-8675-39f9f88b37a13eb18f261d2f0d163f4be7710cf5@w3.org">Exclusion period</a> began on 30 September 2021; ended on 27 February 2022.</p>
@@ -257,22 +257,24 @@
             <dt id="encrypted-media" class="spec">Encrypted Media Extensions</dt>
             <dd>
               <p>This specification extends the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface defined in <a href="https://html.spec.whatwg.org/">HTML</a> to control playback of encrypted content. This revision updates the <a href='https://www.w3.org/TR/encrypted-media/'>W3C Recommendation published in September 2017</a> to address maintenance issues against the specification and add three minor features incubated in the Web Platform Incubator Community Group since then, namely: <a href="https://github.com/WICG/hdcp-detection/blob/master/explainer.md">HDCP Detection</a>, <a href="https://github.com/WICG/encrypted-media-encryption-scheme/blob/master/explainer.md">Encryption scheme capability detection</a> and a means to avoid creating duplicate sessions within the same origin (building on <a href="https://github.com/joeyparrish/encrypted-media-find-session/blob/draft/explainer.md#alternatives-considered">alternatives to finding existing sessions</a>). The inclusion of other features is considered out of scope for this group and would require rechartering.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state</b>: <a href="https://w3c.github.io/encrypted-media/">Editor's Draft</a></p>
             </dd>
 
             <dt id="web-codecs" class="spec">WebCodecs</dt>
             <dd>
               <p>This specification defines interfaces for encoding and decoding of audio, video, and images.</p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i>.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webcodecs/">Working Draft</a></p>
               <p><b>Adopted Draft:</b> WebCodecs, <a href="https://www.w3.org/TR/2023/WD-webcodecs-20230130/">https://www.w3.org/TR/2023/WD-webcodecs-20230130/</a>, 30 January 2023</a>.</p>
               <p><b>Exclusion Draft:</b> WebCodecs, <a href="https://www.w3.org/TR/2021/WD-webcodecs-20210408/">https://www.w3.org/TR/2021/WD-webcodecs-20210408/</a>, 08 April 2021. <a href="https://www.w3.org/mid/cfe-7971-897e1d3aef58cd7a9e8b92552516fd19c1692a51@w3.org">Exclusion period</a> began on 08 April 2021; ended on 05 September 2021.</p>
               <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2019/05/media-wg-charter.html">https://www.w3.org/2019/05/media-wg-charter.html</a>.</p>
             </dd>
 
-            <dt id="audio-focus" class="spec">Audio Focus</dt>
+            <dt id="audio-session" class="spec">Audio Session</dt>
             <dd>
               <p>This specification allows web applications to manage their audio focus, to improve the audio-mixing of websites with native apps so they can play on top of each other or play exclusively.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="First Public Working Draft">FPWD</abbr> Q4 2023 - <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <span class="todo">Editor's Draft</span></p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
             <dt id="media-source" class="spec">Media Source Extensions</dt>
             <dd>
               <p>This specification extends the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface defined in <a href="https://html.spec.whatwg.org/">HTML</a> to allow JavaScript to generate media streams for playback. The scope of this revision is the same as that of the <a href='https://www.w3.org/TR/media-source/'>W3C Recommendation published in November 2016</a>, limited to the generation and control of media streams. This revision updates the W3C Recommendation to address maintenance issues against the specification and add the <a href="https://github.com/wicg/media-source/blob/codec-switching/codec-switching-explainer.md">codec switching</a> feature incubated in the Web Platform Incubator Community Group since then. Additional features that are strictly in the scope of this specification may be considered.</p>
-              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q4 2023 - Recommendation Q4 2024.</p>
+              <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/media-soure-2/">Working Draft</a>.</p>
               <p><b>Adopted Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2022/WD-media-source-2-20220921/">https://www.w3.org/TR/2022/WD-media-source-2-20220921/</a>, 21 September 2022</a>.</p>
               <p><b>Exclusion Draft:</b> Media Source Extensions™, <a href="https://www.w3.org/TR/2021/WD-media-source-2-20210930/">https://www.w3.org/TR/2021/WD-media-source-2-20210930/</a>, 30 September 2021. <a href="https://www.w3.org/mid/cfe-8675-39f9f88b37a13eb18f261d2f0d163f4be7710cf5@w3.org">Exclusion period</a> began on 30 September 2021; ended on 27 February 2022.</p>
@@ -257,6 +257,7 @@
             <dt id="encrypted-media" class="spec">Encrypted Media Extensions</dt>
             <dd>
               <p>This specification extends the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface defined in <a href="https://html.spec.whatwg.org/">HTML</a> to control playback of encrypted content. This revision updates the <a href='https://www.w3.org/TR/encrypted-media/'>W3C Recommendation published in September 2017</a> to address maintenance issues against the specification and add two minor features incubated in the Web Platform Incubator Community Group since then, namely: <a href="https://github.com/WICG/hdcp-detection/blob/master/explainer.md">HDCP Detection</a> and <a href="https://github.com/WICG/encrypted-media-encryption-scheme/blob/master/explainer.md">Encryption scheme capability detection</a>. The inclusion of other features is considered out of scope for this group and would require rechartering.</p>
+              <p class="draft-status"><b>Draft state:</b> <span class="todo">Add FPWD info once available or add Q2 2023 FPWD milestone</span></p>
               <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
             </dd>
 


### PR DESCRIPTION
This fills the expected completion dates with guesstimates based on the last Media WG meeting:
https://www.w3.org/2023/02/14-mediawg-minutes.html#t02

I roughly postponed dates we discussed by half-a-year to avoid being too optimistic. I note that completion dates do not have to fit in the current charter period. In other words, it would be fine to say: "group will not be done on XYZ by Q2 2025".