### PR TITLE
Add ref to TAG design principles, clarify rechartering need

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,9 @@
             <dd>Notes described in <a href="#registries">Registries</a> define optional features for WebCodecs, Media Source Extensions, Encrypted Media Extensions. The Working Group may move them to the Recommendation track.</dd>
           </dl>
 
-          <p>The Working Group will not adopt these features until they have matured through the <a href="https://wicg.io/">Web Platform Incubator Community Group</a> or another similar incubation phase. If additional normative specifications need to be added to the Charter before the Charter expires, the Working Group will recharter with changes.</p>
+          <p>The Working Group will not adopt these features until they have matured through the <a href="https://wicg.io/">Web Platform Incubator Community Group</a> or another similar incubation phase.</p>
+
+          <p>The Working Group will recharter with changes to adopt features beyond those identified in this section as normative specifications.</p>
         </section>
 
         <section id="registries">
@@ -362,6 +364,7 @@
         <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
         <p>To promote interoperability, all changes made to specifications in Candidate Recommendation or to features that have deployed implementations should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>. Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
         <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users, including analysis of <a href="https://www.w3.org/TR/fingerprinting-guidance/">fingerprinting surface introduced</a> and suggested mitigation strategies, as applicable. For features that allow detection and/or negotiation of capabilities, the group will document architectural alternatives, particularly ones that minimize fingerprinting surface, and seek horizontal review as it makes its choice(s) among the alternatives. Where features are imported by reference to other specifications, analysis and mitigation of their privacy and security issues will be included in the referencing specification.</p>
+        <p>This Working Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</p>
         <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations. The latest versions of the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a> and <a href="https://w3c.github.io/apa/fast/">Framework for Accessible Specification of Technologies (FAST)</a> documents notably provide media related advice to ensure that specifications developed by the Working Group meet the needs of users with disabilities.</p>
       </section>
 


### PR DESCRIPTION
This adds a reference to the TAG design principles in the "Success criteria" section, as done in the charter template a couple of months ago, and clarifies that the group will recharter to adopt features beyond those identified in the "Potential normative specifications" section.