### PR TITLE
Align boilerplate text with WG charter template

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,16 +88,16 @@
     </header>
 
     <main>
-      <h1 id="title"><i class="todo">[PROPOSED]</i> Media Working Group Charter</h1>
+      <h1 id="title"><i class="todo">[DRAFT]</i> Media Working Group Charter</h1>
 
       <div class="info">
-        <p>This document is a draft charter proposed for discussion and review by the W3C Advisory Committee. It is available on <a href="https://github.com/w3c/charter-media-wg/">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/charter-media-wg/issues">issues</a>.</p>
+        <p>This document is a draft charter proposed for discussion and review within the Media Working Group and among the W3C Advisory Committee. It is available on <a href="https://github.com/w3c/charter-media-wg/">GitHub</a>. Feel free to raise <a href="https://github.com/w3c/charter-media-wg/issues">issues</a>.</p>
       </div>
 
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/media-wg/">Media Working Group</a> is to develop and improve client-side media processing and playback features on the Web.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/media/join">Join the Media Working Group</a>.</p>
+        <p class="join"><a href="https://www.w3.org/groups/wg/media/join/">Join the Media Working Group</a>.</p>
       </div>
 
       <div id="details">
@@ -107,7 +107,7 @@
               Charter Status
             </th>
             <td>
-              <i class="todo">See the <a href="https://www.w3.org/groups/wg/media/charters">group status page</A> and <a href="#history">detailed change history</a>.</i>
+              See the <a href="https://www.w3.org/groups/wg/media/charters/">group status page</a> and <a href="#history">detailed change history</a>.</i>
             </td>
           </tr>
           <tr id="Duration">
@@ -123,7 +123,7 @@
               End date
             </th>
             <td>
-              <span class="todo">Start date + 2 years</span>
+               <span class="todo">Start date + 2 years</span>
             </td>
           </tr>
 
@@ -138,8 +138,8 @@
               Chairs
             </th>
             <td>
-              Chris Needham (BBC)
-              <br/>Jer Noble (Apple)
+              Marcos Caceres (Apple)
+              <br/>Chris Needham (BBC)
             </td>
           </tr>
           <tr>
@@ -155,7 +155,7 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> topic-specific calls may be held
+              <strong>Teleconferences:</strong> topic-specific calls may be held.
               <br />
               <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
             </td>
@@ -190,8 +190,8 @@
 
       <section id="deliverables">
         <h2>Deliverables</h2>
-        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/media/publications">group publication status page</a>.</p>
-        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state. <i><a href="https://www.w3.org/2021/Process-20211102/#adopted-draft">Adopted Draft</a></i>, <i><a href="https://www.w3.org/2021/Process-20211102/#exclusion-draft">Exclusion Draft</a></i> and <i><a href="https://www.w3.org/2021/Process-20211102/#exclusion-draft-charter">Exclusion Draft Charter</a></i> are defined in the W3C Process Document (section 4.2, Content of a Charter).</p>
+        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/media/publications/">group publication status page</a>.</p>
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state. <i><a href="https://www.w3.org/policies/process/#adopted-draft">Adopted Draft</a></i>, <i><a href="https://www.w3.org/policies/process/#exclusion-draft">Exclusion Draft</a></i> and <i><a href="https://www.w3.org/policies/process/#exclusion-draft-charter">Exclusion Draft Charter</a></i> are defined in the W3C Process Document (section 4.2, Content of a Charter).</p>
 
         <section id="normative">
           <h3>Normative Specifications</h3>
@@ -280,9 +280,9 @@
           </dl>
         </section>
 
-        <section id="potential-normative">
-          <h3>Potential Normative Specifications</h3>
-          <p>The following features have been identified as potential normative specifications and may be adopted as normative specifications by the Working Group if there is consensus in the group that they are ready to move to the Recommendation track:</p>
+        <section id="incubation">
+          <h3>Tentative Deliverables</h3>
+          <p>Depending on the incubation progress, interest from multiple implementers, and the consensus of the Group participants, the Working Group may adopt the following documents as Rec-track specifications:</p>
           <dl>
             <dt><a href="https://github.com/WICG/datacue/blob/master/explainer.md">DataCue</a></dt>
             <dd>An API to support metadata event tracks, carried either in-band or out-of-band and synchronized to audio or video media, which are used to support use cases such as ad insertion or presentation of supplemental content alongside the audio or video.</dd>
@@ -360,10 +360,10 @@
 
       <section id="success-criteria">
         <h2>Success Criteria</h2>
-        <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable implementations</a> of every feature defined in the specification, where interoperability can be verified by passing open test suites, and two or more implementations interoperating with each other. In order to advance to Proposed Recommendation, each normative specification must have an open test suite of every feature defined in the specification.</p>
+        <p>In order to advance beyond <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">Candidate Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable implementations</a> of every feature defined in the specification, where interoperability can be verified by passing open test suites.</p>
         <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
         <p>To promote interoperability, all changes made to specifications in Candidate Recommendation or to features that have deployed implementations should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>. Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
-        <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users, including analysis of <a href="https://www.w3.org/TR/fingerprinting-guidance/">fingerprinting surface introduced</a> and suggested mitigation strategies, as applicable. For features that allow detection and/or negotiation of capabilities, the group will document architectural alternatives, particularly ones that minimize fingerprinting surface, and seek horizontal review as it makes its choice(s) among the alternatives. Where features are imported by reference to other specifications, analysis and mitigation of their privacy and security issues will be included in the referencing specification.</p>
+        <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users, including analysis of <a href="https://www.w3.org/TR/fingerprinting-guidance/">fingerprinting surface introduced</a> and suggested mitigation strategies, as applicable. For features that allow detection and/or negotiation of capabilities, the group will document architectural alternatives, particularly ones that minimize fingerprinting surface, and seek horizontal review as it makes its choice(s) among the alternatives. Where features are imported by reference to other specifications, analysis and mitigation of their privacy and security issues will be included in the referencing specification.</p>
         <p>This Working Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</p>
         <p>Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations. The latest versions of the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a> and <a href="https://w3c.github.io/apa/fast/">Framework for Accessible Specification of Technologies (FAST)</a> documents notably provide media related advice to ensure that specifications developed by the Working Group meet the needs of users with disabilities.</p>
       </section>
@@ -373,15 +373,15 @@
         <p>For all specifications, this Working Group will seek
           <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a>
           for accessibility, internationalization, privacy, and security with the relevant Working and
-          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Interest Groups, and with the <a href="https://www.w3.org/groups/other/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
-          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
+          <a href="https://www.w3.org/policies/process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
           Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
           each specification. The Working Group is advised to seek a review at least 3 months before first entering
-          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
           to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
-        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/policies/process/#WGCharter">W3C Process Document</a>:</p>
 
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
@@ -440,10 +440,10 @@
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
         </p>
         <p>
-          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
         <p>
-          Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.
+          Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
         </p>
       </section>
 
@@ -452,7 +452,7 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/policies/process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
@@ -474,7 +474,7 @@
           Decision Policy
         </h2>
         <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/policies/process/#Consensus"> W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
         <p>
            However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
         </p>
@@ -486,10 +486,10 @@
           If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
-          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs.
         </p>
         <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
+          This charter is written in accordance with the <a href="https://www.w3.org/policies/process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
         </p>
       </section>
 
@@ -498,15 +498,15 @@
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/media/ipr">W3C Patent Policy Implementation</a>.
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/media/ipr/">W3C Patent Policy Implementation</a>.
         </p>
       </section>
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This Working Group will use the <a href="https://www.w3.org/copyright/software-license/">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
 
       <section id="about">
@@ -514,14 +514,14 @@
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="https://www.w3.org/policies/process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/policies/process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">
           <h3>
             Charter History
           </h3>
-          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/policies/process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
           <table class="history">
             <tbody>
@@ -603,7 +603,31 @@
               </tr>
               <tr>
                 <th>
-                  <a href="https://www.w3.org/2021/07/media-wg-charter.html">Rechartered</a>
+                  <a href="https://www.w3.org/2023/06/media-wg-charter.html">Rechartered</a>
+                </th>
+                <td>
+                  26 June 2023
+                </td>
+                <td>
+                  31 May 2025
+                </td>
+                <td>
+                  <ul>
+                    <li>Adjusted boilerplate text to match latest charter template</li>
+                    <li>Added Registries section to highlight registries and registration deliverables</li>
+                    <li>Replaced milestones table with expected and updated completion dates</li>
+                    <li>Moved Audio Session (was Audio Focus) from potential to main list of deliverables</li>
+                    <li>Dropped API to find existing duplicate sessions from the scope of EME updates</li>
+                    <li>Dropped mention of Sourcing In-band Media Resource Tracks from Media Containers into HTML</li>
+                    <li>Adjusted team FTE</li>
+                    <li>Jer Noble steps down as co-Chair</li>
+                    <li>Marcos Caceres appointed as co-Chair</li>
+                  </ul>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <span class="todo">Rechartered</span>
                 </th>
                 <td>
                   <span class="todo">When approved</span>
@@ -614,11 +638,6 @@
                 <td>
                   <ul>
                     <li>Adjusted boilerplate text to match latest charter template</li>
-                    <li>Added Registries section to highlight registries and registration deliverables</li>
-                    <li>Replaced milestones table with expected and updated completion dates</li>
-                    <li>Moved Audio Session (was Audio Focus) from potential to main list of deliverables</li>
-                    <li>Dropped API to find existing duplicate sessions from the scope of EME updates</li>
-                    <li>Dropped mention of Sourcing In-band Media Resource Tracks from Media Containers into HTML</li>
                   </ul>
                 </td>
               </tr>
@@ -636,11 +655,11 @@
       </address>
 
       <p class="copyright">
-        Copyright © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+        Copyright © 2025 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
         <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-        <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+        <a href="https://www.w3.org/policies/#disclaimers">liability</a>,
+        <a href="https://www.w3.org/policies/#trademark">trademark</a> and
+        <a rel="license" href="https://www.w3.org/copyright/software-license/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
       </p>
     </footer>
   </body>


### PR DESCRIPTION
This refreshes the draft charter to align with the latest charter of the group and to integrate changes made to the WG charter template (*) since 2023. Main updates affect:
- links to policy documents
- the "Potential Normative Specifications" section, renamed to "Tentative deliverables"
- mentions of "Proposed Recommendation", replaced with "beyond CR"
- references to the Director, now dropped

(*) https://w3c.github.io/charter-drafts/charter-template.html