### PR TITLE
Add Motivation and Background section

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,15 +166,14 @@
 
       <div id="background" class="background">
         <h2>Motivation and Background</h2>
-        <p>Standardization efforts to develop media foundations for the Web, such as the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface and <a href="https://www.w3.org/TR/media-source/">Media Source Extensions</a>, have helped turn the Web into a major platform for media streaming and media consumption.</p>
-        <p>Experience gained through implementation, deployment and usage of these technologies, standardization of real-time technologies within the <a href="https://www.w3.org/groups/wg/webrtc/">Web Real-Time Communications Working Group</a>, incubation discussions within the <a href="https://wicg.io/">Web Platform Incubator Community Group</a>, and general feedback from the media industry, create new requirements and opportunities to improve the overall media playback experience on the web.</p>
+        <p>Standardization efforts to develop media foundations for the Web, such as the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface and <a href="https://www.w3.org/TR/media-source/">Media Source Extensions</a>, have helped turn the Web into a major platform for media streaming and media consumption, and increasingly for creation of audiovisual media.</p>
+        <p>Experience gained through implementation, deployment and usage of these technologies, standardization of real-time technologies within the <a href="https://www.w3.org/groups/wg/webrtc/">Web Real-Time Communications Working Group</a>, incubation discussions within the <a href="https://wicg.io/">Web Platform Incubator Community Group</a>, and general feedback from the media industry, create new requirements and opportunities to improve the overall media experience on the web.</p>
+        <p>The overall goal of the Media Working Group is to extend media foundations with new standardized technologies to improve client-side media processing and playback on the web.</p>
       </div>
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p>The Media Working Group will extend media foundations with new standardized technologies to improve the overall media playback experience on the Web.</p>
-
-        <p>The <b>scope</b> of the Media Working Group is:</p>
+        <p>The <b>scope</b> of the Media Working Group is to extend media foundations on the web with new standardized technologies for:</p>
         <ul>
           <li>Detection of media capabilities</li>
           <li>Detection of the autoplay policy</li>

--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
     <header id="header">
       <aside>
         <ul id="navbar">
+          <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
           <li><a href="#success-criteria">Success Criteria</a></li>
@@ -163,9 +164,15 @@
         </table>
       </div>
 
+      <div id="background" class="background">
+        <h2>Motivation and Background</h2>
+        <p>Standardization efforts to develop media foundations for the Web, such as the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface and <a href="https://www.w3.org/TR/media-source/">Media Source Extensions</a>, have helped turn the Web into a major platform for media streaming and media consumption.</p>
+        <p>Experience gained through implementation, deployment and usage of these technologies, standardization of real-time technologies within the <a href="https://www.w3.org/groups/wg/webrtc/">Web Real-Time Communications Working Group</a>, incubation discussions within the <a href="https://wicg.io/">Web Platform Incubator Community Group</a>, and general feedback from the media industry, create new requirements and opportunities to improve the overall media playback experience on the web.</p>
+      </div>
+
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p>Standardization efforts to develop media foundations for the Web, such as the <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a> interface and <a href="https://www.w3.org/TR/media-source/">Media Source Extensions</a>, have helped turn the Web into a major platform for media streaming and media consumption. Building on the experience gained through implementation, deployment and usage of these technologies, and on incubation discussions within the <a href="https://wicg.io/">Web Platform Incubator Community Group</a>, the Media Working Group will extend media foundations with new standardized technologies to improve the overall media playback experience on the Web.</p>
+        <p>The Media Working Group will extend media foundations with new standardized technologies to improve the overall media playback experience on the Web.</p>
 
         <p>The <b>scope</b> of the Media Working Group is:</p>
         <ul>
@@ -386,16 +393,16 @@
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
-            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a></dt>
+            <dt><a href="https://www.w3.org/WAI/about/groups/apawg/">Accessible Platform Architectures (APA) Working Group</a></dt>
             <dd>The Media Working Group will coordinate with the APA Working Group to help ensure its deliverables support accessibility requirements, particularly with regard to interoperability with assistive technologies, and inclusion in the deliverables of guidance for implementing the group's deliverables in ways that support accessibility requirements. The Media Working Group will also review updates made to media related requirements in accessibility documents such as the <a href="https://www.w3.org/TR/media-accessibility-reqs/">Media Accessibility User Requirements</a> and <a href="https://w3c.github.io/apa/fast/">Framework for Accessible Specification of Technologies (FAST)</a> documents.</dd>
 
-            <dt><a href="https://www.w3.org/2011/audio/">Audio Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/audio/">Audio Working Group</a></dt>
             <dd>The Audio Working Group develops a client-side API to synthesize, process and render audio streams directly in script.</dd>
 
-            <dt><a href="https://www.w3.org/Style/Group/">CSS Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/css/">CSS Working Group</a></dt>
             <dd>The CSS Working Group develops and maintains <abbr title="Cascading Style Sheets">CSS</abbr>. This includes work on the CSS Object Model. The Media Working Group expects to coordinate with the CSS Working Group on the definition of the screen interface of the Media Capabilities deliverable.</dd>
 
-            <dt><a href="https://www.w3.org/2020/gpu/">GPU for the Web Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/gpu/">GPU for the Web Working Group</a></dt>
             <dd>The GPU for the Web Working Group develops interfaces between the Web Platform and modern 3D graphics and computation capabilities present on native system platforms, including processing of media streams for processing or rendering on the GPU.</dd>
             
             <dt><a href="https://www.w3.org/2011/webtv/">Media and Entertainment Interest Group</a></dt>
@@ -410,7 +417,7 @@
             <dt><a href="https://www.w3.org/groups/wg/webtransport">WebTransport Working Group</a></dt>
             <dd>The WebTransport Working Group develops APIs that enable data transfer between browsers and servers with support for multiple data flows, unidirectional data flows, out-of-order delivery, variable reliability and pluggable protocols. One of the use cases for these APIs is streaming of media, using WebCodecs for media encoding and decoding.</dd>
 
-            <dt><a href="https://www.w3.org/2011/04/webrtc/">Web Real-Time Communications Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/webrtc/">Web Real-Time Communications Working Group</a></dt>
             <dd>The Web Real-Time Communications Working Group develops APIs to capture, encode, process, transfer, decode and render media.</dd>
 
             <dt><a href="https://www.w3.org/community/open-ui/">Open UI Community Group</a></dt>


### PR DESCRIPTION
It is now good practice to have a Motivation and Background section at the beginning of the charter, so that the Scope section can focus on what the group will effectively do. I created one, reusing intro text from the Scope section.

The update also refreshes the home page URLs of groups mentioned in the charter.