### PR TITLE
Add intent to integrate WebCodecs with MSE/EME

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,7 @@
             <dt id="web-codecs" class="spec">WebCodecs</dt>
             <dd>
               <p>This specification defines interfaces for encoding and decoding of audio, video, and images.</p>
+              <p>WebCodecs operates on non-containerized media. To ease integration with pipelines that process containerized media, the Working Group expects to give applications the ability to use an <code>HTMLMediaElement</code> and buffering mechanisms defined in Media Source Extensions to achieve adaptive playback of media that originates from WebCodecs structures. This includes defining a way to represent encrypted audio and video chunks in WebCodecs, along with a way to pass them to Media Source Extensions.</p>
               <p class="milestone"><b>Expected completion:</b> <abbr title="Candidate Recommendation">CR</abbr> Q2 2024 - Recommendation Q2 2025.</p>
               <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webcodecs/">Working Draft</a></p>
               <p><b>Adopted Draft:</b> WebCodecs, <a href="https://www.w3.org/TR/2023/WD-webcodecs-20230130/">https://www.w3.org/TR/2023/WD-webcodecs-20230130/</a>, 30 January 2023</a>.</p>
@@ -644,6 +645,8 @@
                 <td>
                   <ul>
                     <li>Adjusted boilerplate text to match latest charter template</li>
+                    <li>Split Scope section into Background and Scope sections</li>
+                    <li>Mentioned intent to integrate WebCodecs with Media Source Extensions / Encrypted Media Extensions</li>
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
Following Media WG discussions, this completes the description of WebCodecs in the Deliverables section to mention the intent to give applications the ability to use an <code>HTMLMediaElement</code> and buffering mechanisms defined in Media Source Extensions (MSE) to achieve adaptive playback of media that originates from WebCodecs structures, including creating a way to represent encrypted audio/video chunks within WebCodecs so that playback can leverage EME.

I stuck to plain English as much as practical, reusing some wording from the [Chromium bug](https://issues.chromium.org/issues/40155657).

@dalecurtis, PTAL.

People who need to review the charter will need to understand the ins and outs of the change. Below is an attempt to summarize hypothetical implications. Let me know if I got something wrong or missed something!

By itself, the possibility to represent encrypted audio/video chunks in WebCodecs does not extend EME in any way (and EME will not need to be updated at all). In a typical scenario, an encrypted encoded media chunk (`EncodedAudioChunk` or `EncodedVideoChunk`) will be passed to MSE and connected to a `<video>` element. Playback of the encrypted content will then handled by EME, as for any other encrypted content that reaches a `<video>` element.

By definition, encrypted media chunks cannot be decoded as-is into a raw `VideoFrame`, although the spec does not preclude creating an "opaque" `VideoFrame`. If that became possible, such a `VideoFrame` could perhaps in turn be used in other scenarios. It seems worthwhile to review them, although none of them would work out of the box or extend EME in any way:
1. A `VideoFrame` can be injected into a `<video>` element through a [`VideoTrackGenerator`](https://w3c.github.io/mediacapture-transform/#video-track-generator). With encrypted chunks, this would achieve the same thing as connecting it to a `<video>` through MSE+EME (apps would have to handle the buffering themselves, but that's orthogonal to encryption).
2. A `VideoFrame` can be directly injected into a `<canvas>` element. Injecting an encrypted `VideoFrame` into a `<canvas>` will not work out of the box since that would de facto reveal the bytes. The concept of a "tainted canvas", used for cross-origin content, could perhaps be extended for encrypted `VideoFrame`s. For that to work, EME would also need to be integrated to `<canvas>`. If all that happens, this will make it easier to apply content protection to still images, but this is actually already doable in practice, see discussion in https://github.com/w3c/webcodecs/issues/41#issuecomment-2739895730
3. A `VideoFrame` can be imported as external texture into WebGL and WebGPU pipelines. As with `<canvas>`, injecting an encrypted `VideoFrame` will simply not work today because these pipelines do not have provisions for encrypted content, and would require significant work on the APIs and implementations. Should WebGL and WebGPU decide to add support for content protected textures, they would likely want to leverage encrypted structures that can more directly be used as textures than `VideoFrame` in any case.